### PR TITLE
Hi, Kevin. This patch in `feature-func-check' branch will check the parameter `f interface{}' delivered in NewTask procedure body, and provide friendly alert for user.

### DIFF
--- a/drumstick.go
+++ b/drumstick.go
@@ -83,6 +83,9 @@ func NewTask(period time.Duration, f interface{}, args ...interface{}) (*Task, e
 		return nil, errors.New("period is 0,it will crazy running")
 	}
 	newTask := new(Task)
+        if reflect.TypeOf(f).Kind() != reflect.Func {
+                return nil, errors.New("void interface delivered")
+        }
 	newTask.fn = reflect.ValueOf(f)
 	newTask.Quit = make(chan struct{}, 1)
 	newTask.period = period


### PR DESCRIPTION
Once I add border test case to your demo as following:

```go
var fake_func_by_int interface{} = 1
```

and then call this fake void interface by this way:

```go
task, err := drum.NewTask(2*time.Second, fake_func_by_int, "hello", 1, 5)
```
drumstick will panic for the unexpected invoking of a well-designed fake procedure:

panic: reflect: call of reflect.Value.Call on int Value

This patch in _feature-func-check_ branch will check the parameter **f interface{}** delivered in NewTask procedure body, and provide friendly alert for user.